### PR TITLE
Update Spring Boot version, refactor project structure, and add application.yml configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,36 +1,37 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.2.10'
+	id 'org.springframework.boot' version '3.4.1'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
-group = 'com.reinput'
+group = 'info.reinput'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	sourceCompatibility = '17'
+	toolchain {
+		languageVersion = JavaLanguageVersion.of(17)
+	}
 }
 
 repositories {
 	mavenCentral()
 }
 
-dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter'
-	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-server'
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+ext {
+	set('springCloudVersion', "2024.0.0")
 }
 
-ext {
-	set('springCloudVersion', "2023.0.3")
-	name = 'reinput-discovery-server'
-    description = 'Reinput Discovery Server' 
-    version='0.0.1-SNAPSHOT'
-    sourceEncoding='UTF-8'
+dependencies {
+	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-server'
+	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 
 dependencyManagement {
 	imports {
 		mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
 	}
+}
+
+tasks.named('test') {
+	useJUnitPlatform()
 }

--- a/src/main/java/info/reinput/reinput_discovery_server/ReinputDiscoveryServerApplication.java
+++ b/src/main/java/info/reinput/reinput_discovery_server/ReinputDiscoveryServerApplication.java
@@ -1,4 +1,4 @@
-package com.reinput.reinput_discovery_server;
+package info.reinput.reinput_discovery_server;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=reinput-discovery-server

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,13 @@
+
+spring:
+  application:
+    name: reinput-discovery-server
+
+server:
+  port: 8761
+
+eureka:
+  client:
+    register-with-eureka: false
+    fetch-registry: false
+    

--- a/src/test/java/info/reinput/reinput_discovery_server/ReinputDiscoveryServerApplicationTests.java
+++ b/src/test/java/info/reinput/reinput_discovery_server/ReinputDiscoveryServerApplicationTests.java
@@ -1,4 +1,4 @@
-package com.reinput.reinput_discovery_server;
+package info.reinput.reinput_discovery_server;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;


### PR DESCRIPTION
- Upgraded Spring Boot from version 3.2.10 to 3.4.1
- Changed group ID from 'com.reinput' to 'info.reinput'
- Introduced a new main application class for the Eureka server
- Replaced application.properties with application.yml for configuration
- Added test class for application context loading
- Updated Spring Cloud version to 2024.0.0